### PR TITLE
added support for two binds per direction

### DIFF
--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -38,4 +38,4 @@ multiinput = { git="https://github.com/simon-wh/multiinput-rust.git" }
 [features]
 rawinput = []
 ds4 = []
-default=[]
+default=["ds4"]

--- a/src/native/src/config.rs
+++ b/src/native/src/config.rs
@@ -45,13 +45,13 @@ impl Default for KeyMapping {
             #[cfg(not(windows))]
             left_joystick: JoystickKeyMapping {
                 up: 0,
-                up_two: 0,
+                up_two: None,
                 down: 0,
-                down_two: 0,
+                down_two: None,
                 left: 0,
-                left_two: 0,
+                left_two: None,
                 right: 0,
-                right_two: 0,
+                right_two: None,
             },
         }
     }

--- a/src/native/src/config.rs
+++ b/src/native/src/config.rs
@@ -13,13 +13,13 @@ pub struct JoystickAngleConfiguration {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct JoystickKeyMapping {
     pub up: u8,
-    pub up_two: u8,
+    pub up_two: Option<u8>,
     pub left: u8,
-    pub left_two: u8,
+    pub left_two: Option<u8>,
     pub down: u8,
-    pub down_two: u8,
+    pub down_two: Option<u8>,
     pub right: u8,
-    pub right_two: u8,
+    pub right_two: Option<u8>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -34,13 +34,13 @@ impl Default for KeyMapping {
             #[cfg(windows)]
             left_joystick: JoystickKeyMapping {
                 up: KeyId::to_u8(&KeyId::W).unwrap(),
-                up_two: KeyId::to_u8(&KeyId::W).unwrap(),
+                up_two: None,
                 down: KeyId::to_u8(&KeyId::S).unwrap(),
-                down_two: KeyId::to_u8(&KeyId::S).unwrap(),
+                down_two: None,
                 left: KeyId::to_u8(&KeyId::A).unwrap(),
-                left_two: KeyId::to_u8(&KeyId::A).unwrap(),
+                left_two: None,
                 right: KeyId::to_u8(&KeyId::D).unwrap(),
-                right_two: KeyId::to_u8(&KeyId::D).unwrap(),
+                right_two: None,
             },
             #[cfg(not(windows))]
             left_joystick: JoystickKeyMapping {

--- a/src/native/src/config.rs
+++ b/src/native/src/config.rs
@@ -12,13 +12,13 @@ pub struct JoystickAngleConfiguration {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct JoystickKeyMapping {
-    pub up: u8,
+    pub up: Option<u8>,
     pub up_two: Option<u8>,
-    pub left: u8,
+    pub left: Option<u8>,
     pub left_two: Option<u8>,
-    pub down: u8,
+    pub down: Option<u8>,
     pub down_two: Option<u8>,
-    pub right: u8,
+    pub right: Option<u8>,
     pub right_two: Option<u8>,
 }
 
@@ -33,24 +33,24 @@ impl Default for KeyMapping {
         KeyMapping {
             #[cfg(windows)]
             left_joystick: JoystickKeyMapping {
-                up: KeyId::to_u8(&KeyId::W).unwrap(),
+                up: KeyId::to_u8(&KeyId::W),
                 up_two: None,
-                down: KeyId::to_u8(&KeyId::S).unwrap(),
+                down: KeyId::to_u8(&KeyId::S),
                 down_two: None,
-                left: KeyId::to_u8(&KeyId::A).unwrap(),
+                left: KeyId::to_u8(&KeyId::A),
                 left_two: None,
-                right: KeyId::to_u8(&KeyId::D).unwrap(),
+                right: KeyId::to_u8(&KeyId::D),
                 right_two: None,
             },
             #[cfg(not(windows))]
             left_joystick: JoystickKeyMapping {
-                up: 0,
+                up: Some(0),
                 up_two: None,
-                down: 0,
+                down: Some(0),
                 down_two: None,
-                left: 0,
+                left: Some(0),
                 left_two: None,
-                right: 0,
+                right: Some(0),
                 right_two: None,
             },
         }

--- a/src/native/src/config.rs
+++ b/src/native/src/config.rs
@@ -13,9 +13,13 @@ pub struct JoystickAngleConfiguration {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct JoystickKeyMapping {
     pub up: u8,
+    pub up_two: u8,
     pub left: u8,
+    pub left_two: u8,
     pub down: u8,
+    pub down_two: u8,
     pub right: u8,
+    pub right_two: u8,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -30,16 +34,24 @@ impl Default for KeyMapping {
             #[cfg(windows)]
             left_joystick: JoystickKeyMapping {
                 up: KeyId::to_u8(&KeyId::W).unwrap(),
+                up_two: KeyId::to_u8(&KeyId::W).unwrap(),
                 down: KeyId::to_u8(&KeyId::S).unwrap(),
+                down_two: KeyId::to_u8(&KeyId::S).unwrap(),
                 left: KeyId::to_u8(&KeyId::A).unwrap(),
+                left_two: KeyId::to_u8(&KeyId::A).unwrap(),
                 right: KeyId::to_u8(&KeyId::D).unwrap(),
+                right_two: KeyId::to_u8(&KeyId::D).unwrap(),
             },
             #[cfg(not(windows))]
             left_joystick: JoystickKeyMapping {
                 up: 0,
+                up_two: 0,
                 down: 0,
+                down_two: 0,
                 left: 0,
+                left_two: 0,
                 right: 0,
+                right_two: 0,
             },
         }
     }

--- a/src/native/src/controller.rs
+++ b/src/native/src/controller.rs
@@ -8,17 +8,25 @@ use winapi::um::winuser::GetAsyncKeyState;
 
 pub enum JoystickDirection {
     Up,
+    UpTwo,
     Down,
+    DownTwo,
     Left,
+    LeftTwo,
     Right,
-}
+    RightTwo,
+} 
 
 #[derive(Debug)]
 pub struct JoystickState {
     up: bool,
+    up_two: bool,
     down: bool,
+    down_two: bool,
     left: bool,
+    left_two: bool,
     right: bool,
+    right_two: bool
 }
 
 trait UpdateValue {
@@ -90,18 +98,26 @@ impl JoystickState {
     pub fn new() -> Self {
         Self {
             up: false,
+            up_two: false,
             down: false,
+            down_two: false,
             left: false,
+            left_two: false,
             right: false,
+            right_two: false,
         }
     }
 
     pub fn set_direction_state(&mut self, direction: JoystickDirection, state: bool) -> bool {
         match direction {
             JoystickDirection::Up => self.up.update(state),
+            JoystickDirection::UpTwo => self.up_two.update(state),
             JoystickDirection::Down => self.down.update(state),
+            JoystickDirection::DownTwo => self.down_two.update(state),
             JoystickDirection::Left => self.left.update(state),
+            JoystickDirection::LeftTwo => self.left_two.update(state),
             JoystickDirection::Right => self.right.update(state),
+            JoystickDirection::RightTwo => self.right_two.update(state),
         }
     }
 
@@ -119,24 +135,28 @@ impl JoystickState {
     #[allow(dead_code)]
     pub fn update_key_states(&mut self, mappings: &JoystickKeyMapping) -> bool {
         self.update_key_state(JoystickDirection::Up, mappings.up)
+            | self.update_key_state(JoystickDirection::UpTwo, mappings.up_two)
             | self.update_key_state(JoystickDirection::Down, mappings.down)
+            | self.update_key_state(JoystickDirection::DownTwo, mappings.down_two)
             | self.update_key_state(JoystickDirection::Left, mappings.left)
+            | self.update_key_state(JoystickDirection::LeftTwo, mappings.left_two)
             | self.update_key_state(JoystickDirection::Right, mappings.right)
+            | self.update_key_state(JoystickDirection::RightTwo, mappings.right_two)
     }
 
     pub fn _get_xusb_direction_basic(&self) -> (i16, i16) {
         let mut x: i16 = 0;
         let mut y: i16 = 0;
 
-        if self.down && !self.up {
+        if (self.down || self.down_two) && !(self.up || self.up_two) {
             y = i16::MIN;
-        } else if self.up && !self.down {
+        } else if (self.up || self.up_two) && !(self.down || self.down_two) {
             y = i16::MAX;
         }
 
-        if self.left && !self.right {
+        if (self.left || self.left_two) && !(self.right || self.right_two) {
             x = i16::MIN;
-        } else if self.right && !self.left {
+        } else if (self.right || self.right_two) && !(self.left || self.left_two) {
             x = i16::MAX;
         }
 
@@ -147,15 +167,15 @@ impl JoystickState {
         let mut x: f32 = 0.0;
         let mut y: f32 = 0.0;
 
-        if self.down && !self.up {
+        if (self.down || self.down_two) && !(self.up || self.up_two) {
             y = -1.0;
-        } else if self.up && !self.down {
+        } else if (self.up || self.up_two) && !(self.down || self.down_two) {
             y = 1.0;
         }
 
-        if self.left && !self.right {
+        if (self.left || self.left_two) && !(self.right || self.right_two) {
             x = -1.0;
-        } else if self.right && !self.left {
+        } else if (self.right || self.right_two) && !(self.left || self.left_two) {
             x = 1.0;
         }
 

--- a/src/native/src/controller.rs
+++ b/src/native/src/controller.rs
@@ -112,10 +112,13 @@ impl JoystickState {
     }
 
     #[allow(dead_code)]
-    pub fn update_key_state(&mut self, direction: JoystickDirection, bind_one: u8, bind_two: Option<&u8>) -> bool {
+    pub fn update_key_state(&mut self, direction: JoystickDirection, bind_one:  Option<&u8>, bind_two: Option<&u8>) -> bool {
         #[cfg(windows)]
             {
-                let mut key_state = self.get_key_state(bind_one);
+                let mut key_state= false;
+                if let Some(bind_one) = bind_one {
+                    key_state |= self.get_key_state(*bind_one);
+                }
                 if let Some(bind_two) = bind_two {
                     key_state |= self.get_key_state(*bind_two);
                 }
@@ -127,10 +130,10 @@ impl JoystickState {
 
     #[allow(dead_code)]
     pub fn update_key_states(&mut self, mappings: &JoystickKeyMapping) -> bool {
-        self.update_key_state(JoystickDirection::Up, mappings.up, mappings.up_two.as_ref())
-            | self.update_key_state(JoystickDirection::Down, mappings.down, mappings.down_two.as_ref())
-            | self.update_key_state(JoystickDirection::Left, mappings.left, mappings.left_two.as_ref())
-            | self.update_key_state(JoystickDirection::Right, mappings.right, mappings.right_two.as_ref())
+        self.update_key_state(JoystickDirection::Up, mappings.up.as_ref(), mappings.up_two.as_ref())
+            | self.update_key_state(JoystickDirection::Down, mappings.down.as_ref(), mappings.down_two.as_ref())
+            | self.update_key_state(JoystickDirection::Left, mappings.left.as_ref(), mappings.left_two.as_ref())
+            | self.update_key_state(JoystickDirection::Right, mappings.right.as_ref(), mappings.right_two.as_ref())
     }
 
     pub fn _get_xusb_direction_basic(&self) -> (i16, i16) {

--- a/src/native/src/controller.rs
+++ b/src/native/src/controller.rs
@@ -97,12 +97,12 @@ impl JoystickState {
         }
     }
 
-    pub fn set_direction_state(&mut self, direction: JoystickDirection, state: bool) -> bool {
+    pub fn set_direction_state(&mut self, direction: JoystickDirection, state: bool, state_two: bool) -> bool {
         match direction {
-            JoystickDirection::Up => self.up.update(state),
-            JoystickDirection::Down => self.down.update(state),
-            JoystickDirection::Left => self.left.update(state),
-            JoystickDirection::Right => self.right.update(state),
+            JoystickDirection::Up => self.up.update(state || state_two),
+            JoystickDirection::Down => self.down.update(state || state_two),
+            JoystickDirection::Left => self.left.update(state || state_two),
+            JoystickDirection::Right => self.right.update(state || state_two),
         }
     }
 
@@ -112,7 +112,7 @@ impl JoystickState {
             {
                 let bind_one_state = unsafe { GetAsyncKeyState(bind_one as i32) as u32 };
                 let bind_two_state = unsafe { GetAsyncKeyState(bind_two as i32) as u32 };
-                self.set_direction_state(direction, (bind_one_state & 0x8000 != 0) || (bind_two_state & 0x8000 != 0))
+                self.set_direction_state(direction, bind_one_state & 0x8000 != 0, bind_two_state & 0x8000 != 0)
             }
         #[cfg(not(windows))]
             false

--- a/src/native/src/controller.rs
+++ b/src/native/src/controller.rs
@@ -122,8 +122,8 @@ impl JoystickState {
     pub fn update_key_states(&mut self, mappings: &JoystickKeyMapping) -> bool {
         self.update_key_state(JoystickDirection::Up, mappings.up, mappings.up_two.unwrap_or(mappings.up))
             | self.update_key_state(JoystickDirection::Down, mappings.down, mappings.down_two.unwrap_or(mappings.down))
-            | self.update_key_state(JoystickDirection::Left, mappings.left, mappings.left_two.unwrap_or(mappings.down))
-            | self.update_key_state(JoystickDirection::Right, mappings.right, mappings.right_two.unwrap_or(mappings.down))
+            | self.update_key_state(JoystickDirection::Left, mappings.left, mappings.left_two.unwrap_or(mappings.left))
+            | self.update_key_state(JoystickDirection::Right, mappings.right, mappings.right_two.unwrap_or(mappings.right))
     }
 
     pub fn _get_xusb_direction_basic(&self) -> (i16, i16) {

--- a/src/native/src/service.rs
+++ b/src/native/src/service.rs
@@ -160,18 +160,34 @@ impl Service {
                         .controller_state
                         .left_joystick
                         .set_direction_state(JoystickDirection::Up, state == State::Pressed),
+                    x if x == self.config.key_mapping.left_joystick.up_two => self
+                    .controller_state
+                    .left_joystick
+                    .set_direction_state(JoystickDirection::UpTwo, state == State::Pressed),
                     x if x == self.config.key_mapping.left_joystick.down => self
                         .controller_state
                         .left_joystick
                         .set_direction_state(JoystickDirection::Down, state == State::Pressed),
+                    x if x == self.config.key_mapping.left_joystick.down_two => self
+                        .controller_state
+                        .left_joystick
+                        .set_direction_state(JoystickDirection::DownTwo, state == State::Pressed),
                     x if x == self.config.key_mapping.left_joystick.left => self
                         .controller_state
                         .left_joystick
                         .set_direction_state(JoystickDirection::Left, state == State::Pressed),
+                    x if x == self.config.key_mapping.left_joystick.left_two => self
+                        .controller_state
+                        .left_joystick
+                        .set_direction_state(JoystickDirection::LeftTwo, state == State::Pressed),
                     x if x == self.config.key_mapping.left_joystick.right => self
                         .controller_state
                         .left_joystick
                         .set_direction_state(JoystickDirection::Right, state == State::Pressed),
+                    x if x == self.config.key_mapping.left_joystick.right_two => self
+                        .controller_state
+                        .left_joystick
+                        .set_direction_state(JoystickDirection::RightTwo, state == State::Pressed),
                     _ => false,
                 },
                 _ => false,

--- a/src/native/src/service.rs
+++ b/src/native/src/service.rs
@@ -190,35 +190,35 @@ impl Service {
                 RawEvent::KeyboardEvent(_, key, state) => match KeyId::to_u8(&key).unwrap() {
                     x if x == self.config.key_mapping.left_joystick.up => {
                         self.key_bind_state.up = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up, self.key_bind_state.up_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up || self.key_bind_state.up_two)
                     }
                     x if Some(x) == self.config.key_mapping.left_joystick.up_two => {
                         self.key_bind_state.up_two = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up, self.key_bind_state.up_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up || self.key_bind_state.up_two)
                     }
                     x if x == self.config.key_mapping.left_joystick.down => {
                         self.key_bind_state.down = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Down, self.key_bind_state.down, self.key_bind_state.down_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Down, self.key_bind_state.down || self.key_bind_state.down_two)
                     }
                     x if Some(x) == self.config.key_mapping.left_joystick.down_two => {
                         self.key_bind_state.down_two = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Down, self.key_bind_state.down, self.key_bind_state.down_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Down, self.key_bind_state.down || self.key_bind_state.down_two)
                     }
                     x if x == self.config.key_mapping.left_joystick.right => {
                         self.key_bind_state.right = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Right, self.key_bind_state.right, self.key_bind_state.right_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Right, self.key_bind_state.right || self.key_bind_state.right_two)
                     }
                     x if Some(x) == self.config.key_mapping.left_joystick.right_two => {
                         self.key_bind_state.right_two = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Right, self.key_bind_state.right, self.key_bind_state.right_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Right, self.key_bind_state.right || self.key_bind_state.right_two)
                     }
                     x if x == self.config.key_mapping.left_joystick.left => {
                         self.key_bind_state.left = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Left, self.key_bind_state.left, self.key_bind_state.left_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Left, self.key_bind_state.left || self.key_bind_state.left_two)
                     }
                     x if Some(x) == self.config.key_mapping.left_joystick.left_two => {
                         self.key_bind_state.left_two = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Left, self.key_bind_state.left, self.key_bind_state.left_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Left, self.key_bind_state.left || self.key_bind_state.left_two)
                     }
                     _ => false,
                 },

--- a/src/native/src/service.rs
+++ b/src/native/src/service.rs
@@ -213,11 +213,11 @@ impl Service {
                         self.controller_state.left_joystick.set_direction_state(JoystickDirection::Right, self.key_bind_state.right, self.key_bind_state.right_two)
                     }
                     x if x == self.config.key_mapping.left_joystick.left => {
-                        self.key_bind_state.right = state == State::Pressed;
+                        self.key_bind_state.left = state == State::Pressed;
                         self.controller_state.left_joystick.set_direction_state(JoystickDirection::Left, self.key_bind_state.left, self.key_bind_state.left_two)
                     }
                     x if Some(x) == self.config.key_mapping.left_joystick.left_two => {
-                        self.key_bind_state.right_two = state == State::Pressed;
+                        self.key_bind_state.left_two = state == State::Pressed;
                         self.controller_state.left_joystick.set_direction_state(JoystickDirection::Left, self.key_bind_state.left, self.key_bind_state.left_two)
                     }
                     _ => false,

--- a/src/native/src/service.rs
+++ b/src/native/src/service.rs
@@ -46,6 +46,7 @@ unsafe extern "C" fn _handle(
     dbg!(notification.userdata());
 }
 
+#[cfg(feature = "rawinput")]
 pub struct KeyBindState {
     up: bool,
     up_two: bool,
@@ -57,6 +58,7 @@ pub struct KeyBindState {
     right_two: bool,
 }
 
+#[cfg(feature = "rawinput")]
 impl KeyBindState {
     pub fn new() -> Self {
         KeyBindState {
@@ -73,6 +75,7 @@ impl KeyBindState {
 }
 
 pub struct Service {
+    #[cfg(feature = "rawinput")]
     key_bind_state: KeyBindState,
     vigem: Vigem,
     controller: Option<Target>,
@@ -90,6 +93,7 @@ unsafe impl Sync for Service {}
 impl Service {
     pub fn new() -> Self {
         Service {
+            #[cfg(feature = "rawinput")]
             key_bind_state: KeyBindState::new(),
             vigem: Vigem::new(),
             controller: None,

--- a/src/native/src/service.rs
+++ b/src/native/src/service.rs
@@ -1,17 +1,17 @@
-use crate::controller::*;
-#[cfg(windows)]
-#[cfg(feature = "rawinput")]
-use multiinput::*;
-
-use crate::config::ServiceConfiguration;
 use anyhow::{Context, Result};
 use log::*;
 #[cfg(windows)]
+#[cfg(feature = "rawinput")]
+use multiinput::*;
+#[cfg(windows)]
 use vigem::{
+    *,
     notification::*,
     raw::{LPVOID, PVIGEM_CLIENT, PVIGEM_TARGET, UCHAR},
-    *,
 };
+
+use crate::config::ServiceConfiguration;
+use crate::controller::*;
 
 #[cfg(windows)]
 unsafe extern "C" fn _handle(
@@ -46,7 +46,34 @@ unsafe extern "C" fn _handle(
     dbg!(notification.userdata());
 }
 
+pub struct KeyBindState {
+    up: bool,
+    up_two: bool,
+    down: bool,
+    down_two: bool,
+    left: bool,
+    left_two: bool,
+    right: bool,
+    right_two: bool,
+}
+
+impl KeyBindState {
+    pub fn new() -> Self {
+        KeyBindState {
+            up: false,
+            up_two: false,
+            down: false,
+            down_two: false,
+            left: false,
+            left_two: false,
+            right: false,
+            right_two: false,
+        }
+    }
+}
+
 pub struct Service {
+    key_bind_state: KeyBindState,
     vigem: Vigem,
     controller: Option<Target>,
     #[cfg(feature = "rawinput")]
@@ -63,6 +90,7 @@ unsafe impl Sync for Service {}
 impl Service {
     pub fn new() -> Self {
         Service {
+            key_bind_state: KeyBindState::new(),
             vigem: Vigem::new(),
             controller: None,
             controller_state: ControllerState::new(),
@@ -156,38 +184,38 @@ impl Service {
             // debug!("{:?}", event);
             match event {
                 RawEvent::KeyboardEvent(_, key, state) => match KeyId::to_u8(&key).unwrap() {
-                    x if x == self.config.key_mapping.left_joystick.up => self
-                        .controller_state
-                        .left_joystick
-                        .set_direction_state(JoystickDirection::Up, state == State::Pressed),
-                    x if x == self.config.key_mapping.left_joystick.up_two => self
-                    .controller_state
-                    .left_joystick
-                    .set_direction_state(JoystickDirection::UpTwo, state == State::Pressed),
-                    x if x == self.config.key_mapping.left_joystick.down => self
-                        .controller_state
-                        .left_joystick
-                        .set_direction_state(JoystickDirection::Down, state == State::Pressed),
-                    x if x == self.config.key_mapping.left_joystick.down_two => self
-                        .controller_state
-                        .left_joystick
-                        .set_direction_state(JoystickDirection::DownTwo, state == State::Pressed),
-                    x if x == self.config.key_mapping.left_joystick.left => self
-                        .controller_state
-                        .left_joystick
-                        .set_direction_state(JoystickDirection::Left, state == State::Pressed),
-                    x if x == self.config.key_mapping.left_joystick.left_two => self
-                        .controller_state
-                        .left_joystick
-                        .set_direction_state(JoystickDirection::LeftTwo, state == State::Pressed),
-                    x if x == self.config.key_mapping.left_joystick.right => self
-                        .controller_state
-                        .left_joystick
-                        .set_direction_state(JoystickDirection::Right, state == State::Pressed),
-                    x if x == self.config.key_mapping.left_joystick.right_two => self
-                        .controller_state
-                        .left_joystick
-                        .set_direction_state(JoystickDirection::RightTwo, state == State::Pressed),
+                    x if x == self.config.key_mapping.left_joystick.up => {
+                        self.key_bind_state.up = state == State::Pressed;
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up, self.key_bind_state.right_two)
+                    }
+                    x if Some(x) == self.config.key_mapping.left_joystick.up_two => {
+                        self.key_bind_state.up_two = state == State::Pressed;
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up, self.key_bind_state.right_two)
+                    }
+                    x if x == self.config.key_mapping.left_joystick.down => {
+                        self.key_bind_state.down = state == State::Pressed;
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Down, self.key_bind_state.down, self.key_bind_state.down_two)
+                    }
+                    x if Some(x) == self.config.key_mapping.left_joystick.down_two => {
+                        self.key_bind_state.down_two = state == State::Pressed;
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Down, self.key_bind_state.down, self.key_bind_state.down_two)
+                    }
+                    x if x == self.config.key_mapping.left_joystick.right => {
+                        self.key_bind_state.right = state == State::Pressed;
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Right, self.key_bind_state.right, self.key_bind_state.right_two)
+                    }
+                    x if Some(x) == self.config.key_mapping.left_joystick.right_two => {
+                        self.key_bind_state.right_two = state == State::Pressed;
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Right, self.key_bind_state.right, self.key_bind_state.right_two)
+                    }
+                    x if x == self.config.key_mapping.left_joystick.left => {
+                        self.key_bind_state.right = state == State::Pressed;
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Left, self.key_bind_state.left, self.key_bind_state.left_two)
+                    }
+                    x if Some(x) == self.config.key_mapping.left_joystick.left_two => {
+                        self.key_bind_state.right_two = state == State::Pressed;
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Left, self.key_bind_state.left, self.key_bind_state.left_two)
+                    }
                     _ => false,
                 },
                 _ => false,

--- a/src/native/src/service.rs
+++ b/src/native/src/service.rs
@@ -190,11 +190,11 @@ impl Service {
                 RawEvent::KeyboardEvent(_, key, state) => match KeyId::to_u8(&key).unwrap() {
                     x if x == self.config.key_mapping.left_joystick.up => {
                         self.key_bind_state.up = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up, self.key_bind_state.right_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up, self.key_bind_state.up_two)
                     }
                     x if Some(x) == self.config.key_mapping.left_joystick.up_two => {
                         self.key_bind_state.up_two = state == State::Pressed;
-                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up, self.key_bind_state.right_two)
+                        self.controller_state.left_joystick.set_direction_state(JoystickDirection::Up, self.key_bind_state.up, self.key_bind_state.up_two)
                     }
                     x if x == self.config.key_mapping.left_joystick.down => {
                         self.key_bind_state.down = state == State::Pressed;

--- a/src/native/types.ts
+++ b/src/native/types.ts
@@ -11,13 +11,13 @@ export const defaultJoystickAngles: JoystickAngleConfiguration = {
 };
 
 export interface JoystickKeyMapping {
-  up: number;
+  up?: number;
   up_two?: number;
-  down: number;
+  down?: number;
   down_two?: number;
-  left: number;
+  left?: number;
   left_two?: number;
-  right: number;
+  right?: number;
   right_two?: number;
 }
 
@@ -28,13 +28,9 @@ export interface KeyMapping {
 export const defaultKeyMapping: KeyMapping = {
   leftJoystick: {
     up: Key.W,
-    up_two: undefined,
     down: Key.S,
-    down_two: undefined,
     left: Key.A,
-    left_two: undefined,
     right: Key.D,
-    right_two: undefined,
   },
 };
 

--- a/src/native/types.ts
+++ b/src/native/types.ts
@@ -12,9 +12,13 @@ export const defaultJoystickAngles: JoystickAngleConfiguration = {
 
 export interface JoystickKeyMapping {
   up: number;
+  up_two: number;
   down: number;
+  down_two: number;
   left: number;
+  left_two: number;
   right: number;
+  right_two: number;
 }
 
 export interface KeyMapping {
@@ -24,9 +28,13 @@ export interface KeyMapping {
 export const defaultKeyMapping: KeyMapping = {
   leftJoystick: {
     up: Key.W,
+    up_two: Key.W,
     down: Key.S,
+    down_two: Key.S,
     left: Key.A,
+    left_two: Key.A,
     right: Key.D,
+    right_two: Key.D
   },
 };
 export interface ServiceConfiguration {

--- a/src/native/types.ts
+++ b/src/native/types.ts
@@ -12,13 +12,13 @@ export const defaultJoystickAngles: JoystickAngleConfiguration = {
 
 export interface JoystickKeyMapping {
   up: number;
-  up_two: number;
+  up_two?: number;
   down: number;
-  down_two: number;
+  down_two?: number;
   left: number;
-  left_two: number;
+  left_two?: number;
   right: number;
-  right_two: number;
+  right_two?: number;
 }
 
 export interface KeyMapping {
@@ -28,15 +28,16 @@ export interface KeyMapping {
 export const defaultKeyMapping: KeyMapping = {
   leftJoystick: {
     up: Key.W,
-    up_two: Key.W,
+    up_two: undefined,
     down: Key.S,
-    down_two: Key.S,
+    down_two: undefined,
     left: Key.A,
-    left_two: Key.A,
+    left_two: undefined,
     right: Key.D,
-    right_two: Key.D
+    right_two: undefined,
   },
 };
+
 export interface ServiceConfiguration {
   leftJoystickAngles: JoystickAngleConfiguration;
   keyMapping: KeyMapping;

--- a/src/view/AdvancedSettings.tsx
+++ b/src/view/AdvancedSettings.tsx
@@ -117,12 +117,20 @@ export function EditKeyBind(props: EditKeybindProps & InputProps) {
   const { optional, value, valueChanged, ...rest } = props;
   const [isEditing, setIsEditing] = useState(false);
 
+  function removeCurrentBind() {
+    if (!optional) {
+      return;
+    }
+
+    props.valueChanged(undefined);
+    setIsEditing(false)
+  }
+
   function assignNewBind() {
     setIsEditing(true);
     window.addEventListener(
       "keydown",
       (event) => {
-        console.log(event, optional, event.keyCode === Key.Escape && optional ? null : event.keyCode);
         props.valueChanged(event.keyCode === Key.Escape && optional ? undefined : event.keyCode);
         setIsEditing(false);
       },
@@ -134,6 +142,7 @@ export function EditKeyBind(props: EditKeybindProps & InputProps) {
     <Input
       value={!isEditing ? (props.value ? Key[props.value] : "") : ""}
       onClick={assignNewBind}
+      onContextMenu={removeCurrentBind}
       isReadOnly={true}
       placeholder={isEditing ? "Press any key" : "Click to set"}
       size="sm"

--- a/src/view/AdvancedSettings.tsx
+++ b/src/view/AdvancedSettings.tsx
@@ -183,7 +183,7 @@ export function KeyBinding() {
           <HStack justifyContent="space-between">
             <ArrowDownIcon color={iconColor}/>
             <Text width="100px" variant="body">
-              Forward
+              Back
             </Text>
           </HStack>
           <EditKeyBind
@@ -201,7 +201,7 @@ export function KeyBinding() {
           <HStack justifyContent="space-between">
             <ArrowBackIcon color={iconColor}/>
             <Text width="100px" variant="body">
-              Forward
+              Left
             </Text>
           </HStack>
           <EditKeyBind
@@ -219,7 +219,7 @@ export function KeyBinding() {
           <HStack justifyContent="space-between">
             <ArrowForwardIcon color={iconColor}/>
             <Text width="100px" variant="body">
-              Forward
+              Right
             </Text>
           </HStack>
           <EditKeyBind

--- a/src/view/AdvancedSettings.tsx
+++ b/src/view/AdvancedSettings.tsx
@@ -1,4 +1,9 @@
-import { ArrowBackIcon, ArrowDownIcon, ArrowForwardIcon, ArrowUpIcon, } from "@chakra-ui/icons";
+import {
+  ArrowBackIcon,
+  ArrowDownIcon,
+  ArrowForwardIcon,
+  ArrowUpIcon,
+} from "@chakra-ui/icons";
 import {
   Accordion,
   AccordionButton,
@@ -26,7 +31,11 @@ import {
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { bigWindowSize, smallWindowSize } from "../common";
-import { defaultJoystickAngles, defaultKeyMapping, JoystickKeyMapping, } from "../native/types";
+import {
+  defaultJoystickAngles,
+  defaultKeyMapping,
+  JoystickKeyMapping,
+} from "../native/types";
 import { Key } from "ts-keycode-enum";
 import { Card } from "./Components";
 import { RemoteStore, setWindowSize, useRemoteValue } from "./ipc";
@@ -57,9 +66,9 @@ function AngleSlider(
         {...rest}
       >
         <SliderTrack>
-          <SliderFilledTrack backgroundColor="yellow.500"/>
+          <SliderFilledTrack backgroundColor="yellow.500" />
         </SliderTrack>
-        <SliderThumb _focus={{ boxShadow: "base" }}/>
+        <SliderThumb _focus={{ boxShadow: "base" }} />
       </Slider>
       <NumberInput
         onChange={(_, value) => {
@@ -76,10 +85,10 @@ function AngleSlider(
         // allowMouseWheel
         focusInputOnChange={false}
       >
-        <NumberInputField/>
+        <NumberInputField />
         <NumberInputStepper>
-          <NumberIncrementStepper/>
-          <NumberDecrementStepper/>
+          <NumberIncrementStepper />
+          <NumberDecrementStepper />
         </NumberInputStepper>
       </NumberInput>
     </HStack>
@@ -108,22 +117,17 @@ function AngleControl() {
 }
 
 interface EditKeybindProps {
-  optional: boolean;
   value?: number;
   valueChanged: (value?: number) => void;
 }
 
 export function EditKeyBind(props: EditKeybindProps & InputProps) {
-  const { optional, value, valueChanged, ...rest } = props;
+  const { value, valueChanged, ...rest } = props;
   const [isEditing, setIsEditing] = useState(false);
 
   function removeCurrentBind() {
-    if (!optional) {
-      return;
-    }
-
     props.valueChanged(undefined);
-    setIsEditing(false)
+    setIsEditing(false);
   }
 
   function assignNewBind() {
@@ -131,7 +135,7 @@ export function EditKeyBind(props: EditKeybindProps & InputProps) {
     window.addEventListener(
       "keydown",
       (event) => {
-        props.valueChanged(event.keyCode === Key.Escape && optional ? undefined : event.keyCode);
+        props.valueChanged(event.keyCode);
         setIsEditing(false);
       },
       { once: true }
@@ -158,7 +162,10 @@ export function KeyBinding() {
     defaultKeyMapping
   );
 
-  function assignNewJoystickBind(key: keyof JoystickKeyMapping, value?: number) {
+  function assignNewJoystickBind(
+    key: keyof JoystickKeyMapping,
+    value?: number
+  ) {
     setKeyMapping({
       ...keyMapping,
       leftJoystick: { ...keyMapping.leftJoystick, [key]: value },
@@ -173,19 +180,18 @@ export function KeyBinding() {
         <Text variant="heading">Key bindings</Text>
         <Flex>
           <HStack justifyContent="space-between">
-            <ArrowUpIcon color={iconColor}/>
+            <ArrowUpIcon color={iconColor} />
             <Text width="100px" variant="body">
               Forward
             </Text>
           </HStack>
           <EditKeyBind
-            optional={false}
-            mr={1} flex={1}
+            mr={1}
+            flex={1}
             value={keyMapping.leftJoystick.up}
             valueChanged={(value) => assignNewJoystickBind("up", value)}
           />
           <EditKeyBind
-            optional={true}
             flex={1}
             value={keyMapping.leftJoystick.up_two}
             valueChanged={(value) => assignNewJoystickBind("up_two", value)}
@@ -193,19 +199,18 @@ export function KeyBinding() {
         </Flex>
         <Flex>
           <HStack justifyContent="space-between">
-            <ArrowDownIcon color={iconColor}/>
+            <ArrowDownIcon color={iconColor} />
             <Text width="100px" variant="body">
               Back
             </Text>
           </HStack>
           <EditKeyBind
-            optional={false}
-            mr={1} flex={1}
+            mr={1}
+            flex={1}
             value={keyMapping.leftJoystick.down}
             valueChanged={(value) => assignNewJoystickBind("down", value)}
           />
           <EditKeyBind
-            optional={true}
             flex={1}
             value={keyMapping.leftJoystick.down_two}
             valueChanged={(value) => assignNewJoystickBind("down_two", value)}
@@ -213,19 +218,18 @@ export function KeyBinding() {
         </Flex>
         <Flex>
           <HStack justifyContent="space-between">
-            <ArrowBackIcon color={iconColor}/>
+            <ArrowBackIcon color={iconColor} />
             <Text width="100px" variant="body">
               Left
             </Text>
           </HStack>
           <EditKeyBind
-            optional={false}
-            mr={1} flex={1}
+            mr={1}
+            flex={1}
             value={keyMapping.leftJoystick.left}
             valueChanged={(value) => assignNewJoystickBind("left", value)}
           />
           <EditKeyBind
-            optional={true}
             flex={1}
             value={keyMapping.leftJoystick.left_two}
             valueChanged={(value) => assignNewJoystickBind("left_two", value)}
@@ -233,20 +237,19 @@ export function KeyBinding() {
         </Flex>
         <Flex>
           <HStack justifyContent="space-between">
-            <ArrowForwardIcon color={iconColor}/>
+            <ArrowForwardIcon color={iconColor} />
             <Text width="100px" variant="body">
               Right
             </Text>
           </HStack>
           <EditKeyBind
-            optional={false}
-            mr={1} flex={1}
+            mr={1}
+            flex={1}
             value={keyMapping.leftJoystick.right}
             valueChanged={(value) => assignNewJoystickBind("right", value)}
           />
           <EditKeyBind
             flex={1}
-            optional={true}
             value={keyMapping.leftJoystick.right_two}
             valueChanged={(value) => assignNewJoystickBind("right_two", value)}
           />
@@ -279,12 +282,12 @@ export function AdvancedSettingsCard() {
             <Text variant="heading" flex="1" textAlign="left">
               Advanced mode
             </Text>
-            <AccordionIcon/>
+            <AccordionIcon />
           </AccordionButton>
           <AccordionPanel pb={4}>
             <VStack align="baseline" spacing="2">
-              <KeyBinding/>
-              <AngleControl/>
+              <KeyBinding />
+              <AngleControl />
               <Link
                 as={Text}
                 variant="body"

--- a/src/view/AdvancedSettings.tsx
+++ b/src/view/AdvancedSettings.tsx
@@ -187,6 +187,10 @@ export function KeyBinding() {
         }
       );
     }
+
+    return () => {
+      window.removeEventListener("keydown", listener);
+    };
   }, [editingState]);
 
   function assignNewJoystickBind(

--- a/src/view/AdvancedSettings.tsx
+++ b/src/view/AdvancedSettings.tsx
@@ -155,6 +155,11 @@ export function KeyBinding() {
   const [editingState, setEditingState] = editingStateState;
 
   const listener = (event: any) => {
+    if (event.keyCode === 27) {
+      setEditingState(undefined);
+      return;
+    }
+
     if (editingState !== undefined) {
       assignNewJoystickBind(
         editingState as keyof JoystickKeyMapping,

--- a/src/view/AdvancedSettings.tsx
+++ b/src/view/AdvancedSettings.tsx
@@ -1,47 +1,36 @@
+import { ArrowBackIcon, ArrowDownIcon, ArrowForwardIcon, ArrowUpIcon, } from "@chakra-ui/icons";
 import {
-  ArrowUpIcon,
-  ArrowDownIcon,
-  ArrowBackIcon,
-  ArrowForwardIcon,
-} from "@chakra-ui/icons";
-import {
-  SliderProps,
-  InputProps,
-  StackProps,
-  ExpandedIndex,
   Accordion,
   AccordionButton,
   AccordionIcon,
   AccordionItem,
   AccordionPanel,
+  ExpandedIndex,
+  Flex,
   HStack,
   Input,
-  InputGroup,
-  InputRightAddon,
+  InputProps,
   Link,
-  Slider,
-  SliderFilledTrack,
-  SliderThumb,
-  SliderTrack,
-  Text,
-  VStack,
-  NumberInput,
   NumberDecrementStepper,
   NumberIncrementStepper,
+  NumberInput,
   NumberInputField,
   NumberInputStepper,
+  Slider,
+  SliderFilledTrack,
+  SliderProps,
+  SliderThumb,
+  SliderTrack,
+  StackProps,
+  Text,
+  VStack,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { bigWindowSize, smallWindowSize } from "../common";
-import {
-  defaultJoystickAngles,
-  defaultKeyMapping,
-  JoystickKeyMapping,
-} from "../native/types";
+import { defaultJoystickAngles, defaultKeyMapping, JoystickKeyMapping, } from "../native/types";
 import { Key } from "ts-keycode-enum";
 import { Card } from "./Components";
-import { useRemoteValue, setWindowSize, RemoteStore } from "./ipc";
-import { parse } from "path";
+import { RemoteStore, setWindowSize, useRemoteValue } from "./ipc";
 
 const strafeAngleRange: [number, number] = [15 / 90, 72 / 90];
 
@@ -155,24 +144,32 @@ export function EditKeyBind(props: EditKeybindProps & InputProps) {
 }
 
 interface EditKeybindRowProps {
-  label: string;
+  label: string | null;
   leftIcon: React.ReactFragment;
 }
 
 export function EditKeybindRow(
   props: EditKeybindRowProps & EditKeybindProps & StackProps
 ) {
-  const { leftIcon, label, value, valueChanged, ...rest } = props;
+  const {leftIcon, label, value, valueChanged, ...rest} = props;
 
-  return (
-    <HStack {...rest} justifyContent="space-between">
-      {leftIcon}
-      <Text width="200px" variant="body">
-        {label}
-      </Text>
-      <EditKeyBind value={value} valueChanged={valueChanged} />
-    </HStack>
-  );
+  if (label !== null)
+    return (
+      <HStack {...rest} justifyContent="space-between">
+        {leftIcon}
+        <Text width="200px" variant="body">
+          {label}
+        </Text>
+        <EditKeyBind value={value} valueChanged={valueChanged}/>
+      </HStack>
+    );
+  else {
+    return (
+      <HStack {...rest} justifyContent="space-between">
+        <EditKeyBind value={value} valueChanged={valueChanged}/>
+      </HStack>
+    );
+  }
 }
 
 export function KeyBinding() {
@@ -194,30 +191,70 @@ export function KeyBinding() {
     <>
       <VStack align="left">
         <Text variant="heading">Key bindings</Text>
-        <EditKeybindRow
-          leftIcon={<ArrowUpIcon color={iconColor} />}
-          label="Forward"
-          value={keyMapping.leftJoystick.up}
-          valueChanged={(value) => assignNewJoystickBind("up", value)}
-        />
-        <EditKeybindRow
-          leftIcon={<ArrowDownIcon color={iconColor} />}
-          label="Back"
-          value={keyMapping.leftJoystick.down}
-          valueChanged={(value) => assignNewJoystickBind("down", value)}
-        />
-        <EditKeybindRow
-          leftIcon={<ArrowBackIcon color={iconColor} />}
-          label="Left"
-          value={keyMapping.leftJoystick.left}
-          valueChanged={(value) => assignNewJoystickBind("left", value)}
-        />
-        <EditKeybindRow
-          leftIcon={<ArrowForwardIcon color={iconColor} />}
-          label="Right"
-          value={keyMapping.leftJoystick.right}
-          valueChanged={(value) => assignNewJoystickBind("right", value)}
-        />
+        <Flex>
+          <EditKeybindRow
+            mr={1} flex={1}
+            leftIcon={<ArrowUpIcon color={iconColor}/>}
+            label="Forward"
+            value={keyMapping.leftJoystick.up}
+            valueChanged={(value) => assignNewJoystickBind("up", value)}
+          />
+          <EditKeybindRow
+            flex={1}
+            leftIcon={<ArrowUpIcon color={iconColor}/>}
+            label={null}
+            value={keyMapping.leftJoystick.up_two}
+            valueChanged={(value) => assignNewJoystickBind("up_two", value)}
+          />
+        </Flex>
+        <Flex>
+          <EditKeybindRow
+            mr={1} flex={1}
+            leftIcon={<ArrowDownIcon color={iconColor}/>}
+            label="Back"
+            value={keyMapping.leftJoystick.down}
+            valueChanged={(value) => assignNewJoystickBind("down", value)}
+          />
+          <EditKeybindRow
+            flex={1}
+            leftIcon={<ArrowDownIcon color={iconColor}/>}
+            label={null}
+            value={keyMapping.leftJoystick.down_two}
+            valueChanged={(value) => assignNewJoystickBind("down_two", value)}
+          />
+        </Flex>
+        <Flex>
+          <EditKeybindRow
+            mr={1} flex={1}
+            leftIcon={<ArrowBackIcon color={iconColor}/>}
+            label="Left"
+            value={keyMapping.leftJoystick.left}
+            valueChanged={(value) => assignNewJoystickBind("left", value)}
+          />
+          <EditKeybindRow
+            flex={1}
+            leftIcon={<ArrowBackIcon color={iconColor}/>}
+            label={null}
+            value={keyMapping.leftJoystick.left_two}
+            valueChanged={(value) => assignNewJoystickBind("left_two", value)}
+          />
+        </Flex>
+        <Flex>
+          <EditKeybindRow
+            mr={1} flex={1}
+            leftIcon={<ArrowForwardIcon color={iconColor}/>}
+            label="Right"
+            value={keyMapping.leftJoystick.right}
+            valueChanged={(value) => assignNewJoystickBind("right", value)}
+          />
+          <EditKeybindRow
+            flex={1}
+            leftIcon={<ArrowForwardIcon color={iconColor}/>}
+            label={null}
+            value={keyMapping.leftJoystick.right_two}
+            valueChanged={(value) => assignNewJoystickBind("right_two", value)}
+          />
+        </Flex>
       </VStack>
     </>
   );

--- a/src/view/AdvancedSettings.tsx
+++ b/src/view/AdvancedSettings.tsx
@@ -57,9 +57,9 @@ function AngleSlider(
         {...rest}
       >
         <SliderTrack>
-          <SliderFilledTrack backgroundColor="yellow.500" />
+          <SliderFilledTrack backgroundColor="yellow.500"/>
         </SliderTrack>
-        <SliderThumb _focus={{ boxShadow: "base" }} />
+        <SliderThumb _focus={{ boxShadow: "base" }}/>
       </Slider>
       <NumberInput
         onChange={(_, value) => {
@@ -76,10 +76,10 @@ function AngleSlider(
         // allowMouseWheel
         focusInputOnChange={false}
       >
-        <NumberInputField />
+        <NumberInputField/>
         <NumberInputStepper>
-          <NumberIncrementStepper />
-          <NumberDecrementStepper />
+          <NumberIncrementStepper/>
+          <NumberDecrementStepper/>
         </NumberInputStepper>
       </NumberInput>
     </HStack>
@@ -108,12 +108,13 @@ function AngleControl() {
 }
 
 interface EditKeybindProps {
-  value: number;
-  valueChanged: (value: number) => void;
+  optional: boolean;
+  value?: number;
+  valueChanged: (value?: number) => void;
 }
 
 export function EditKeyBind(props: EditKeybindProps & InputProps) {
-  const { value, valueChanged, ...rest } = props;
+  const { optional, value, valueChanged, ...rest } = props;
   const [isEditing, setIsEditing] = useState(false);
 
   function assignNewBind() {
@@ -121,8 +122,8 @@ export function EditKeyBind(props: EditKeybindProps & InputProps) {
     window.addEventListener(
       "keydown",
       (event) => {
-        console.log(event);
-        props.valueChanged(event.keyCode);
+        console.log(event, optional, event.keyCode === Key.Escape && optional ? null : event.keyCode);
+        props.valueChanged(event.keyCode === Key.Escape && optional ? undefined : event.keyCode);
         setIsEditing(false);
       },
       { once: true }
@@ -131,10 +132,10 @@ export function EditKeyBind(props: EditKeybindProps & InputProps) {
 
   return (
     <Input
-      value={!isEditing ? Key[props.value] : ""}
+      value={!isEditing ? (props.value ? Key[props.value] : "") : ""}
       onClick={assignNewBind}
       isReadOnly={true}
-      placeholder="Press any key"
+      placeholder={isEditing ? "Press any key" : "Click to set"}
       size="sm"
       cursor="pointer"
       {...rest}
@@ -148,7 +149,7 @@ export function KeyBinding() {
     defaultKeyMapping
   );
 
-  function assignNewJoystickBind(key: keyof JoystickKeyMapping, value: number) {
+  function assignNewJoystickBind(key: keyof JoystickKeyMapping, value?: number) {
     setKeyMapping({
       ...keyMapping,
       leftJoystick: { ...keyMapping.leftJoystick, [key]: value },
@@ -169,11 +170,13 @@ export function KeyBinding() {
             </Text>
           </HStack>
           <EditKeyBind
+            optional={false}
             mr={1} flex={1}
             value={keyMapping.leftJoystick.up}
             valueChanged={(value) => assignNewJoystickBind("up", value)}
           />
           <EditKeyBind
+            optional={true}
             flex={1}
             value={keyMapping.leftJoystick.up_two}
             valueChanged={(value) => assignNewJoystickBind("up_two", value)}
@@ -187,11 +190,13 @@ export function KeyBinding() {
             </Text>
           </HStack>
           <EditKeyBind
+            optional={false}
             mr={1} flex={1}
             value={keyMapping.leftJoystick.down}
-            valueChanged={(value)=> assignNewJoystickBind("down", value)}
+            valueChanged={(value) => assignNewJoystickBind("down", value)}
           />
           <EditKeyBind
+            optional={true}
             flex={1}
             value={keyMapping.leftJoystick.down_two}
             valueChanged={(value) => assignNewJoystickBind("down_two", value)}
@@ -205,11 +210,13 @@ export function KeyBinding() {
             </Text>
           </HStack>
           <EditKeyBind
+            optional={false}
             mr={1} flex={1}
             value={keyMapping.leftJoystick.left}
             valueChanged={(value) => assignNewJoystickBind("left", value)}
           />
           <EditKeyBind
+            optional={true}
             flex={1}
             value={keyMapping.leftJoystick.left_two}
             valueChanged={(value) => assignNewJoystickBind("left_two", value)}
@@ -223,12 +230,14 @@ export function KeyBinding() {
             </Text>
           </HStack>
           <EditKeyBind
+            optional={false}
             mr={1} flex={1}
             value={keyMapping.leftJoystick.right}
             valueChanged={(value) => assignNewJoystickBind("right", value)}
           />
           <EditKeyBind
             flex={1}
+            optional={true}
             value={keyMapping.leftJoystick.right_two}
             valueChanged={(value) => assignNewJoystickBind("right_two", value)}
           />
@@ -261,12 +270,12 @@ export function AdvancedSettingsCard() {
             <Text variant="heading" flex="1" textAlign="left">
               Advanced mode
             </Text>
-            <AccordionIcon />
+            <AccordionIcon/>
           </AccordionButton>
           <AccordionPanel pb={4}>
             <VStack align="baseline" spacing="2">
-              <KeyBinding />
-              <AngleControl />
+              <KeyBinding/>
+              <AngleControl/>
               <Link
                 as={Text}
                 variant="body"

--- a/src/view/AdvancedSettings.tsx
+++ b/src/view/AdvancedSettings.tsx
@@ -21,7 +21,6 @@ import {
   SliderProps,
   SliderThumb,
   SliderTrack,
-  StackProps,
   Text,
   VStack,
 } from "@chakra-ui/react";
@@ -143,35 +142,6 @@ export function EditKeyBind(props: EditKeybindProps & InputProps) {
   );
 }
 
-interface EditKeybindRowProps {
-  label: string | null;
-  leftIcon: React.ReactFragment;
-}
-
-export function EditKeybindRow(
-  props: EditKeybindRowProps & EditKeybindProps & StackProps
-) {
-  const {leftIcon, label, value, valueChanged, ...rest} = props;
-
-  if (label !== null)
-    return (
-      <HStack {...rest} justifyContent="space-between">
-        {leftIcon}
-        <Text width="200px" variant="body">
-          {label}
-        </Text>
-        <EditKeyBind value={value} valueChanged={valueChanged}/>
-      </HStack>
-    );
-  else {
-    return (
-      <HStack {...rest} justifyContent="space-between">
-        <EditKeyBind value={value} valueChanged={valueChanged}/>
-      </HStack>
-    );
-  }
-}
-
 export function KeyBinding() {
   const [keyMapping, setKeyMapping] = useRemoteValue(
     "keyMapping",
@@ -192,65 +162,73 @@ export function KeyBinding() {
       <VStack align="left">
         <Text variant="heading">Key bindings</Text>
         <Flex>
-          <EditKeybindRow
+          <HStack justifyContent="space-between">
+            <ArrowUpIcon color={iconColor}/>
+            <Text width="100px" variant="body">
+              Forward
+            </Text>
+          </HStack>
+          <EditKeyBind
             mr={1} flex={1}
-            leftIcon={<ArrowUpIcon color={iconColor}/>}
-            label="Forward"
             value={keyMapping.leftJoystick.up}
             valueChanged={(value) => assignNewJoystickBind("up", value)}
           />
-          <EditKeybindRow
+          <EditKeyBind
             flex={1}
-            leftIcon={<ArrowUpIcon color={iconColor}/>}
-            label={null}
             value={keyMapping.leftJoystick.up_two}
             valueChanged={(value) => assignNewJoystickBind("up_two", value)}
           />
         </Flex>
         <Flex>
-          <EditKeybindRow
+          <HStack justifyContent="space-between">
+            <ArrowDownIcon color={iconColor}/>
+            <Text width="100px" variant="body">
+              Forward
+            </Text>
+          </HStack>
+          <EditKeyBind
             mr={1} flex={1}
-            leftIcon={<ArrowDownIcon color={iconColor}/>}
-            label="Back"
             value={keyMapping.leftJoystick.down}
-            valueChanged={(value) => assignNewJoystickBind("down", value)}
+            valueChanged={(value)=> assignNewJoystickBind("down", value)}
           />
-          <EditKeybindRow
+          <EditKeyBind
             flex={1}
-            leftIcon={<ArrowDownIcon color={iconColor}/>}
-            label={null}
             value={keyMapping.leftJoystick.down_two}
             valueChanged={(value) => assignNewJoystickBind("down_two", value)}
           />
         </Flex>
         <Flex>
-          <EditKeybindRow
+          <HStack justifyContent="space-between">
+            <ArrowBackIcon color={iconColor}/>
+            <Text width="100px" variant="body">
+              Forward
+            </Text>
+          </HStack>
+          <EditKeyBind
             mr={1} flex={1}
-            leftIcon={<ArrowBackIcon color={iconColor}/>}
-            label="Left"
             value={keyMapping.leftJoystick.left}
             valueChanged={(value) => assignNewJoystickBind("left", value)}
           />
-          <EditKeybindRow
+          <EditKeyBind
             flex={1}
-            leftIcon={<ArrowBackIcon color={iconColor}/>}
-            label={null}
             value={keyMapping.leftJoystick.left_two}
             valueChanged={(value) => assignNewJoystickBind("left_two", value)}
           />
         </Flex>
         <Flex>
-          <EditKeybindRow
+          <HStack justifyContent="space-between">
+            <ArrowForwardIcon color={iconColor}/>
+            <Text width="100px" variant="body">
+              Forward
+            </Text>
+          </HStack>
+          <EditKeyBind
             mr={1} flex={1}
-            leftIcon={<ArrowForwardIcon color={iconColor}/>}
-            label="Right"
             value={keyMapping.leftJoystick.right}
             valueChanged={(value) => assignNewJoystickBind("right", value)}
           />
-          <EditKeybindRow
+          <EditKeyBind
             flex={1}
-            leftIcon={<ArrowForwardIcon color={iconColor}/>}
-            label={null}
             value={keyMapping.leftJoystick.right_two}
             valueChanged={(value) => assignNewJoystickBind("right_two", value)}
           />


### PR DESCRIPTION
In Fortnite you can bind a direction of movement to two different keys, so i added support for it in the wooting double movement utility too.
This is useful if you have bindings like me, where u can't press some key combinations while strafing / moving if u have only one key assigned.

![image](https://user-images.githubusercontent.com/57702380/116325882-819ddd00-a7c3-11eb-8406-2a87c88a89bd.png)
